### PR TITLE
update version and re-order requests

### DIFF
--- a/certified-connectors/Team Forms/apiDefinition.swagger.json
+++ b/certified-connectors/Team Forms/apiDefinition.swagger.json
@@ -3,7 +3,7 @@
   "info": {
     "title": "Team Forms",
     "description": "Teams Forms brings digital forms into Microsoft Teams. The software will empower your teams to build and deliver forms from within the productivity tools that they already know and trust. Unlike many other forms solutions on the market, Team Forms talks directly with your Teams SharePoint so that data captured by forms remains in your ownership and never leaves your trusted office 365 environment.",
-    "version": "1.1.0",
+    "version": "1.1.1",
     "termsOfService": "https://teamforms.app/terms",
     "contact": {
       "name": "Team Forms",
@@ -13,9 +13,7 @@
   },
   "host": "api.teamforms.app",
   "basePath": "/",
-  "schemes": [
-    "https"
-  ],
+  "schemes": ["https"],
   "consumes": [],
   "produces": [],
   "paths": {
@@ -215,69 +213,6 @@
           "$ref": "#/definitions/dynamicResponseSchema"
         }
       },
-      "post": {
-        "responses": {
-          "201": {
-            "description": "created",
-            "schema": {}
-          }
-        },
-        "summary": "When a new form response is submitted",
-        "description": "Triggered a flow when a response is submitted in Team Forms.",
-        "operationId": "SubscribeResponse",
-        "x-ms-visibility": "important",
-        "x-ms-trigger": "single",
-        "consumes": [
-          "application/json"
-        ],
-        "parameters": [
-          {
-            "$ref": "#/parameters/groupId"
-          },
-          {
-            "name": "formId",
-            "in": "query",
-            "type": "string",
-            "description": "Unique id for the form. Leave blank to trigger for all forms in the selected team.",
-            "x-ms-summary": "Form",
-            "x-ms-visibility": "important",
-            "x-ms-dynamic-values": {
-              "operationId": "Forms",
-              "value-path": "fields/tfFormId",
-              "value-title": "fields/tfTitle",
-              "parameters": {
-                "groupId": {
-                  "parameter": "groupId"
-                }
-              }
-            }
-          },
-          {
-            "$ref": "#/parameters/environment"
-          },
-          {
-            "$ref": "#/parameters/triggers"
-          },
-          {
-            "name": "requestBody",
-            "in": "body",
-            "required": true,
-            "schema": {
-              "type": "object",
-              "properties": {
-                "webHookUrl": {
-                  "type": "string",
-                  "x-ms-visibility": "internal",
-                  "x-ms-notification-url": true
-                }
-              },
-              "required": [
-                "webHookUrl"
-              ]
-            }
-          }
-        ]
-      },
       "delete": {
         "responses": {
           "200": {
@@ -323,14 +258,6 @@
           }
         ],
         "x-ms-visibility": "internal"
-      }
-    },
-    "/response-deletion-subscription": {
-      "x-ms-notification-content": {
-        "description": "Webhook response",
-        "schema": {
-          "$ref": "#/definitions/dynamicResponseSchema"
-        }
       },
       "post": {
         "responses": {
@@ -339,14 +266,12 @@
             "schema": {}
           }
         },
-        "summary": "When a form response is deleted",
-        "description": "Triggered a flow when a response is deleted in Team Forms.",
-        "operationId": "SubscribeResponseDeletion",
+        "summary": "When a new form response is submitted",
+        "description": "Triggered a flow when a response is submitted in Team Forms.",
+        "operationId": "SubscribeResponse",
         "x-ms-visibility": "important",
         "x-ms-trigger": "single",
-        "consumes": [
-          "application/json"
-        ],
+        "consumes": ["application/json"],
         "parameters": [
           {
             "$ref": "#/parameters/groupId"
@@ -370,6 +295,12 @@
             }
           },
           {
+            "$ref": "#/parameters/environment"
+          },
+          {
+            "$ref": "#/parameters/triggers"
+          },
+          {
             "name": "requestBody",
             "in": "body",
             "required": true,
@@ -382,12 +313,18 @@
                   "x-ms-notification-url": true
                 }
               },
-              "required": [
-                "webHookUrl"
-              ]
+              "required": ["webHookUrl"]
             }
           }
         ]
+      }
+    },
+    "/response-deletion-subscription": {
+      "x-ms-notification-content": {
+        "description": "Webhook response",
+        "schema": {
+          "$ref": "#/definitions/dynamicResponseSchema"
+        }
       },
       "delete": {
         "responses": {
@@ -434,6 +371,59 @@
           }
         ],
         "x-ms-visibility": "internal"
+      },
+      "post": {
+        "responses": {
+          "201": {
+            "description": "created",
+            "schema": {}
+          }
+        },
+        "summary": "When a form response is deleted",
+        "description": "Triggered a flow when a response is deleted in Team Forms.",
+        "operationId": "SubscribeResponseDeletion",
+        "x-ms-visibility": "important",
+        "x-ms-trigger": "single",
+        "consumes": ["application/json"],
+        "parameters": [
+          {
+            "$ref": "#/parameters/groupId"
+          },
+          {
+            "name": "formId",
+            "in": "query",
+            "type": "string",
+            "description": "Unique id for the form. Leave blank to trigger for all forms in the selected team.",
+            "x-ms-summary": "Form",
+            "x-ms-visibility": "important",
+            "x-ms-dynamic-values": {
+              "operationId": "Forms",
+              "value-path": "fields/tfFormId",
+              "value-title": "fields/tfTitle",
+              "parameters": {
+                "groupId": {
+                  "parameter": "groupId"
+                }
+              }
+            }
+          },
+          {
+            "name": "requestBody",
+            "in": "body",
+            "required": true,
+            "schema": {
+              "type": "object",
+              "properties": {
+                "webHookUrl": {
+                  "type": "string",
+                  "x-ms-visibility": "internal",
+                  "x-ms-notification-url": true
+                }
+              },
+              "required": ["webHookUrl"]
+            }
+          }
+        ]
       }
     }
   },
@@ -795,11 +785,7 @@
       "in": "query",
       "type": "string",
       "description": "Types of events to trigger this workflow. Submitted and Resubmitted by default",
-      "enum": [
-        "Submitted",
-        "Resubmitted",
-        "Submitted and Resubmitted"
-      ],
+      "enum": ["Submitted", "Resubmitted", "Submitted and Resubmitted"],
       "x-ms-summary": "Triggers",
       "x-ms-visibility": "advanced"
     },
@@ -807,10 +793,7 @@
       "name": "environment",
       "in": "query",
       "type": "string",
-      "enum": [
-        "draft",
-        "published"
-      ],
+      "enum": ["draft", "published"],
       "description": "The environment to set.",
       "required": false,
       "x-ms-summary": "Environment",
@@ -822,7 +805,7 @@
     "oauth2_auth": {
       "type": "oauth2",
       "flow": "accessCode",
-      "authorizationUrl": "https://login.windows.net/common/oauth2/authorize",
+      "authorizationUrl": "https://login.microsoftonline.com/common/oauth2/authorize",
       "tokenUrl": "https://login.windows.net/common/oauth2/authorize",
       "scopes": {}
     }


### PR DESCRIPTION
- Updated schema version to match the schema version that will be in production
- Re-arranged the order of operations (delete,post) so that it matches the order that is produced by Microsoft when you upload a schema and re-download it. This ensures when we compare a schema thats been processed by Microsoft against our own schema without confusing diffs that result from the different sorting orders.